### PR TITLE
Fix typos again

### DIFF
--- a/lib/libdbr/__init__.py
+++ b/lib/libdbr/__init__.py
@@ -18,7 +18,7 @@ __version_dev = 0
 def version():
   return __version
 
-## Retreives version information as a string.
+## Retrieves version information as a string.
 def versionString():
   ver = strings.toString(__version, sep=".")
   if __version_dev > 0:

--- a/lib/libdbr/bin.py
+++ b/lib/libdbr/bin.py
@@ -18,7 +18,7 @@ import sys
 from . import paths
 
 
-## Creates a uniform agument list.
+## Creates a uniform argument list.
 #
 #  @param args
 #    List of arguments.

--- a/lib/libdbr/config.py
+++ b/lib/libdbr/config.py
@@ -74,7 +74,7 @@ class Config:
           return False
     return True
 
-  ## Parses config file data into a managable list.
+  ## Parses config file data into a manageable list.
   #
   #  @return
   #    List of file contents.
@@ -230,7 +230,7 @@ class Config:
     conf.insert(insert_idx, Pair(key, strings.toString(value, sep=sep)))
     self.__sections[section] = conf
 
-  ## Retreives a string value from config.
+  ## Retrieves a string value from config.
   #
   #  @param key
   #    String identifier.
@@ -264,7 +264,7 @@ class Config:
       raise KeyError("key '{}' not found in config {} and 'default' not set".format(key, suffix))
     return default
 
-  ## Retreives a boolean value from config.
+  ## Retrieves a boolean value from config.
   #
   #  @param key
   #    String identifier.
@@ -277,7 +277,7 @@ class Config:
   def getBool(self, key, default=None, section=None):
     return strings.boolFromString(self.getValue(key, default, section))
 
-  ## Retreives an integer value from config.
+  ## Retrieves an integer value from config.
   #
   #  @param key
   #    String identifier.
@@ -294,7 +294,7 @@ class Config:
       return value
     return int(value)
 
-  ## Retreives a float value from config.
+  ## Retrieves a float value from config.
   #
   #  @param key
   #    String identifier.
@@ -307,7 +307,7 @@ class Config:
   def getFloat(self, key, default=None, section=None):
     return strings.floatFromString(self.getValue(key, default, section))
 
-  ## Retreives a list value from config.
+  ## Retrieves a list value from config.
   #
   #  @param key
   #    String identifier.
@@ -324,7 +324,7 @@ class Config:
   def getList(self, key, default=None, section=None, sep=",", handler=str):
     return strings.listFromString(self.getValue(key, default, section), sep, handler)
 
-  ## Retreives a key-value pair value from config.
+  ## Retrieves a key-value pair value from config.
   #
   #  @param key
   #    String identifier.
@@ -513,7 +513,7 @@ def clearDefaults():
   for key in __config_defaults:
     del __config_defaults[key]
 
-## Parses config file data into a managable list.
+## Parses config file data into a manageable list.
 #
 #  @return
 #    List of file contents.

--- a/lib/libdbr/fileio.py
+++ b/lib/libdbr/fileio.py
@@ -30,7 +30,7 @@ from zipfile import ZipFile
 from . import paths
 
 
-# line ending delimeter
+# line ending delimiter
 __le = "\n"
 
 # default file & directory permissions
@@ -280,7 +280,7 @@ def makeDir(dirpath, mode=__perm["d"], verbose=False):
     return err, msg
   os.makedirs(dirpath)
   if not os.path.isdir(dirpath):
-    return 1, "failed to create directory, an unknown error occured: {}".format(dirpath)
+    return 1, "failed to create directory, an unknown error occurred: {}".format(dirpath)
   os.chmod(dirpath, mode)
   if verbose:
     print("new directory '{}' (mode={})".format(dirpath, oct(mode)[2:]))
@@ -300,7 +300,7 @@ def deleteFile(filepath, verbose=False):
       return errno.EISDIR, "cannot delete file, directory exists: {}".format(filepath)
     os.remove(filepath)
     if os.path.lexists(filepath):
-      return 1, "failed to delete file, an unknown error occured: {}".format(filepath)
+      return 1, "failed to delete file, an unknown error occurred: {}".format(filepath)
     if verbose:
       print("delete file '{}'".format(filepath))
   return 0, None

--- a/lib/libdbr/strings.py
+++ b/lib/libdbr/strings.py
@@ -287,7 +287,7 @@ def isInteger(st):
     return False
   return True
 
-## Checks if a string represents a numberic value.
+## Checks if a string represents a numeric value.
 #
 #  @param st
 #    String or bytes object to check.

--- a/lib/libdbr/unittest.py
+++ b/lib/libdbr/unittest.py
@@ -41,7 +41,7 @@ def runTest(test_name, test_file=None, verbose=False):
     # FIXME: correct error code?
     return 1, msg
   if "init" not in test_data.__dict__:
-    msg = "'{}' does not define funtion 'init', cannot run test".format(test_name)
+    msg = "'{}' does not define function 'init', cannot run test".format(test_name)
     __logger.error(msg)
     # FIXME: correct error code?
     return 1, msg

--- a/lib/libdebreate/appinfo.py
+++ b/lib/libdebreate/appinfo.py
@@ -26,7 +26,7 @@ __dbr_standard = (1, 0)
 def getVersion():
   return __version
 
-## Retreives app development version.
+## Retrieves app development version.
 #
 #  @return
 #    Development version integer.

--- a/lib/libdebreate/dbrfile.py
+++ b/lib/libdebreate/dbrfile.py
@@ -42,7 +42,7 @@ class DBRFile:
     self.project_data = {}
     self.setFile(filepath)
 
-    # detectected standard & app versions from project file
+    # detected standard & app versions from project file
     self.dbr_standard = None
     self.app_version = None
 

--- a/ui/wizard.py
+++ b/ui/wizard.py
@@ -323,7 +323,7 @@ class Wizard(wx.Panel):
       page_ids.append(P.GetId())
     return tuple(page_ids)
 
-  ## Alias of `ui.wizard.Wizard.getPagesIdList` for backword compatibility.
+  ## Alias of `ui.wizard.Wizard.getPagesIdList` for backward compatibility.
   #
   #  @deprecated
   #    Use `ui.wizard.Wizard.getPagesIdList`.

--- a/util/depends.py
+++ b/util/depends.py
@@ -50,4 +50,4 @@ def checkWx():
     sys.exit(1)
   if wx_ver < wx_rec:
     tmp = ".".join(str(wx_rec).strip("[]").split(", "))
-    logger.warn("minimum recommened version of wxPython is {}, but found {}, app may not function as intended".format(tmp, wx.__version__))
+    logger.warn("minimum recommended version of wxPython is {}, but found {}, app may not function as intended".format(tmp, wx.__version__))

--- a/wizbin/__init__.py
+++ b/wizbin/__init__.py
@@ -8,4 +8,4 @@
 
 ## Wizard pages related to binary package building.
 #
-#  @pacakge wizbin
+#  @package wizbin


### PR DESCRIPTION
Found via `codespell -S locale,templates -L paket,sie,fo,nd,te`