### PR TITLE
Contrib for debian packaging of debreate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ build
 INSTALLED
 
 # Debian dist files
-debian/changelog
+# debian/changelog
 debian/debreate
 debian/debhelper-build-stamp
 debian/debreate.debhelper.log

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ X-Python-Version: >= 3.10
 
 Package: debreate
 Architecture: all
-Depends: ${misc:Depends}, python3 (>=3.10), python3-wxgtk4.2|python3-pip|python3-wxgtk4.1|python3-wxgtk4.0 (>=4.0.7), fakeroot, dpkg (>=1.0.0), util-linux (>=2.0.0), debianutils (>=4.0.0)
+Depends: ${misc:Depends}, python3 (>=3.10), python3-wxgtk4.2|python3-pip|python3-wxgtk4.1|python3-wxgtk4.0 (>=4.0.7), fakeroot, dpkg (>=1.0.0), util-linux (>=2.0.0), debianutils (>=4.0.0), python3-wxgtk-webview4.0
 Recommends: file, lintian, xdg-utils, man-db, gzip (>=1.0), binutils, x11-server-utils, libc-bin
 Suggests: gdebi|gdebi-kde|qapt-deb-installer
 Description: Debian Package Builder
@@ -23,8 +23,3 @@ Description: Debian Package Builder
  anything that does not require being compiled from source, such as scripted
  applications or media. These packages can then be used for personal
  distribution.
- .
- Plans for using backends such as dh_make & debuild for creating source packages
- are in the works. But source packaging can be quite different & is a must if
- you want to get your packages into a distribution's official repositories or a
- Launchpad Personal Package Archive (PPA).

--- a/lib/libdbr/sysinfo.py
+++ b/lib/libdbr/sysinfo.py
@@ -19,6 +19,7 @@ import sys
 __msys_list = ("msys", "mingw32", "mingw64", "clang32", "clang64", "clangarm64", "ucrt64")
 
 __core_name = sys.platform
+__os_name = os.name
 if __core_name == "win32":
   __os_name = __core_name
   __msys = (os.getenv("MSYSTEM") or "").lower()

--- a/ui/main.py
+++ b/ui/main.py
@@ -258,6 +258,14 @@ class MainWindow(wx.Frame):
       ),
       "hugo.posnic@gmail.com"
     )
+    
+    about.AddJobs(
+      "Emmanuel Farhi",
+      (
+        GT("Code Contributor"),
+      ),
+      "emmanuel.farhi.1@gmail.com"
+    )
 
     about.AddJob("Lander Usategui San Juan", GT("General Contributor"), "lander@erlerobotics.com")
 


### PR DESCRIPTION
Hi Jordan,

You've done a lot of great work since I looked at your tool in 2023. 
I've fixed an error in the current main (`os.name`), and also re-enable `debuild -b`. I took the liberty to put my name in the Credits as (minor) contributor.

For the future, I propose to summit `debreate` as an official debian package, as I'm now Debian maintainer.
This will allow an easy distribution channel via usual `apt install debreate`. This is better than Launchpad, as it also propagates to all Debian-class Linux derivatives. Do you agree on that ?
Could you create a 0.8.9 Tag for release ?

Cheers, Emmanuel.